### PR TITLE
Add extra logic and UI to match-3 game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-"# jnjnjnj" 
+# Match-3 Game
+
+This repository contains a small match-3 game (similar to Candy Crush) built with HTML, CSS and JavaScript.
+
+Open `index.html` in your browser to play. The page includes a scoreboard with your score, number of moves and time played. You can restart the game at any moment using the **Restart** button.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Match-3 Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Match-3 Game</h1>
+  <div id="board"></div>
+  <div id="scoreboard">
+    <div id="score">Score: 0</div>
+    <div id="moves">Moves: 0</div>
+    <div id="timer">Time: 0s</div>
+    <button id="restart">Restart</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,175 @@
+const board = document.getElementById('board');
+const scoreDisplay = document.getElementById('score');
+const movesDisplay = document.getElementById('moves');
+const timerDisplay = document.getElementById('timer');
+const restartBtn = document.getElementById('restart');
+const width = 8;
+const colors = ['red', 'yellow', 'green', 'blue', 'purple'];
+const squares = [];
+let score = 0;
+let moves = 0;
+let startTime = Date.now();
+
+function updateScore(points) {
+  score += points;
+  scoreDisplay.textContent = 'Score: ' + score;
+}
+
+function updateMoves() {
+  moves++;
+  movesDisplay.textContent = 'Moves: ' + moves;
+}
+
+setInterval(() => {
+  const seconds = Math.floor((Date.now() - startTime) / 1000);
+  timerDisplay.textContent = 'Time: ' + seconds + 's';
+}, 1000);
+
+restartBtn.addEventListener('click', restartGame);
+
+function restartGame() {
+  score = 0;
+  moves = 0;
+  startTime = Date.now();
+  scoreDisplay.textContent = 'Score: 0';
+  movesDisplay.textContent = 'Moves: 0';
+  timerDisplay.textContent = 'Time: 0s';
+  board.innerHTML = '';
+  squares.length = 0;
+  createBoard();
+  addEventListeners();
+}
+
+function createBoard() {
+  for (let i = 0; i < width * width; i++) {
+    const square = document.createElement('div');
+    square.setAttribute('draggable', true);
+    square.setAttribute('id', i);
+    const randomColor = colors[Math.floor(Math.random() * colors.length)];
+    square.className = 'square ' + randomColor;
+    board.appendChild(square);
+    squares.push(square);
+  }
+}
+createBoard();
+addEventListeners();
+
+function addEventListeners() {
+  squares.forEach(square => square.addEventListener('dragstart', dragStart));
+  squares.forEach(square => square.addEventListener('dragend', dragEnd));
+  squares.forEach(square => square.addEventListener('dragover', e => e.preventDefault()));
+  squares.forEach(square => square.addEventListener('dragenter', e => e.preventDefault()));
+  squares.forEach(square => square.addEventListener('dragleave', () => {}));
+  squares.forEach(square => square.addEventListener('drop', dragDrop));
+}
+
+let colorBeingDragged;
+let colorBeingReplaced;
+let squareIdBeingDragged;
+let squareIdBeingReplaced;
+
+
+function dragStart() {
+  colorBeingDragged = this.classList[1];
+  squareIdBeingDragged = parseInt(this.id);
+}
+
+function dragDrop() {
+  colorBeingReplaced = this.classList[1];
+  squareIdBeingReplaced = parseInt(this.id);
+  this.classList.remove(colorBeingReplaced);
+  this.classList.add(colorBeingDragged);
+  squares[squareIdBeingDragged].classList.remove(colorBeingDragged);
+  squares[squareIdBeingDragged].classList.add(colorBeingReplaced);
+}
+
+function dragEnd() {
+  let validMoves = [squareIdBeingDragged - 1, squareIdBeingDragged - width, squareIdBeingDragged + 1, squareIdBeingDragged + width];
+  let validMove = validMoves.includes(squareIdBeingReplaced);
+
+  if (squareIdBeingReplaced && validMove) {
+    updateMoves();
+    squareIdBeingReplaced = null;
+    checkBoard();
+  } else if (squareIdBeingReplaced && !validMove) {
+    squares[squareIdBeingDragged].classList.remove(squares[squareIdBeingDragged].classList[1]);
+    squares[squareIdBeingDragged].classList.add(colorBeingDragged);
+
+    squares[squareIdBeingReplaced].classList.remove(squares[squareIdBeingReplaced].classList[1]);
+    squares[squareIdBeingReplaced].classList.add(colorBeingReplaced);
+  } else {
+    squares[squareIdBeingDragged].classList.remove(squares[squareIdBeingDragged].classList[1]);
+    squares[squareIdBeingDragged].classList.add(colorBeingDragged);
+  }
+}
+
+function checkRowForThree() {
+  for (let i = 0; i < 64; i++) {
+    const rowOfThree = [i, i + 1, i + 2];
+    const decidedColor = squares[i].classList[1];
+    const notValid = [6, 7, 14, 15, 22, 23, 30, 31, 38, 39, 46, 47, 54, 55, 62, 63];
+    if (notValid.includes(i)) continue;
+    if (decidedColor && rowOfThree.every(index => squares[index].classList[1] === decidedColor)) {
+      rowOfThree.forEach(index => squares[index].className = 'square');
+      updateScore(3);
+    }
+  }
+}
+
+function checkColumnForThree() {
+  for (let i = 0; i < 48; i++) {
+    const columnOfThree = [i, i + width, i + width * 2];
+    const decidedColor = squares[i].classList[1];
+    if (decidedColor && columnOfThree.every(index => squares[index].classList[1] === decidedColor)) {
+      columnOfThree.forEach(index => squares[index].className = 'square');
+      updateScore(3);
+    }
+  }
+}
+
+function checkRowForFour() {
+  for (let i = 0; i < 64; i++) {
+    const rowOfFour = [i, i + 1, i + 2, i + 3];
+    const decidedColor = squares[i].classList[1];
+    const notValid = [5,6,7,13,14,15,21,22,23,29,30,31,37,38,39,45,46,47,53,54,55,61,62,63];
+    if (notValid.includes(i)) continue;
+    if (decidedColor && rowOfFour.every(index => squares[index].classList[1] === decidedColor)) {
+      rowOfFour.forEach(index => squares[index].className = 'square');
+      updateScore(4);
+    }
+  }
+}
+
+function checkColumnForFour() {
+  for (let i = 0; i < 32; i++) {
+    const columnOfFour = [i, i + width, i + width * 2, i + width * 3];
+    const decidedColor = squares[i].classList[1];
+    if (decidedColor && columnOfFour.every(index => squares[index].classList[1] === decidedColor)) {
+      columnOfFour.forEach(index => squares[index].className = 'square');
+      updateScore(4);
+    }
+  }
+}
+
+function moveDown() {
+  for (let i = 0; i < 56; i++) {
+    if (squares[i + width].classList.length === 1) {
+      squares[i + width].classList.add(squares[i].classList[1]);
+      squares[i].className = 'square';
+      if (i < width && squares[i].classList.length === 1) {
+        let randomColor = colors[Math.floor(Math.random() * colors.length)];
+        squares[i].className = 'square ' + randomColor;
+      }
+    }
+  }
+}
+
+function checkBoard() {
+  checkRowForFour();
+  checkColumnForFour();
+  checkRowForThree();
+  checkColumnForThree();
+  moveDown();
+}
+
+window.setInterval(checkBoard, 100);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,38 @@
+body {
+  text-align: center;
+  font-family: Arial, sans-serif;
+}
+
+#board {
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(8, 50px);
+  grid-template-rows: repeat(8, 50px);
+  gap: 2px;
+  width: max-content;
+}
+
+.square {
+  width: 50px;
+  height: 50px;
+}
+
+.red { background: #e74c3c; }
+.yellow { background: #f1c40f; }
+.green { background: #2ecc71; }
+.blue { background: #3498db; }
+.purple { background: #9b59b6; }
+
+#scoreboard {
+  margin-top: 15px;
+}
+
+#scoreboard div {
+  margin: 5px;
+  font-size: 18px;
+}
+
+#restart {
+  padding: 5px 10px;
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add scoreboard with score, moves and timer
- allow restarting the game
- track moves and update score for rows/columns of three or four
- highlight new CSS styles for scoreboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684107558a5083268211f535c13e3177